### PR TITLE
Fixed DLL_PROCESS_ATTACH ERROR

### DIFF
--- a/framework/dllmain.cpp
+++ b/framework/dllmain.cpp
@@ -16,7 +16,7 @@ BOOL APIENTRY DllMain( HMODULE hModule,
     {
     case DLL_PROCESS_ATTACH:
         init_il2cpp();
-        CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE) Run, NULL, 0, NULL);
+        CreateThread(NULL, 0, reinterpret_cast<LPTHREAD_START_ROUTINE>(Run), NULL, 0, NULL);
         break;
     case DLL_THREAD_ATTACH:
     case DLL_THREAD_DETACH:


### PR DESCRIPTION
Because void only works if called reinterpret_cast<LPTHREAD_START_ROUTINE>, DWORD WINAPI works if called only "(LPTHREAD_START_ROUTINE)"